### PR TITLE
jep exceptions include full python traceback and/or java stacktrace

### DIFF
--- a/src/jep/Util.java
+++ b/src/jep/Util.java
@@ -1,5 +1,8 @@
 package jep;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 /**
  * <pre>
  * Util.java - utility functions
@@ -168,4 +171,21 @@ public final class Util {
 
         return JOBJECT_ID;
     }
+
+
+    /**
+     * Returns a String version of the throwable with the stacktrace
+     *  
+     * @param throwable
+     *            the throwable
+     * @return the throwable's stacktrace
+     */
+     public static String throwableAsString(Throwable throwable) {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        throwable.printStackTrace(printWriter);
+        return stringWriter.toString();
+     }
+
+
 }

--- a/src/jep/util.h
+++ b/src/jep/util.h
@@ -108,9 +108,15 @@ void release_utf_char(JNIEnv*, jstring, const char*);
 // int param is printTrace, send traceback to stderr
 int process_py_exception(JNIEnv*, int);
 
+// convert pytraceback to string
+char* PyTraceback_AsString(PyObject*);
+
 // convert java exception to pyerr.
 // true (1) if an exception was processed.
 int process_java_exception(JNIEnv*);
+
+// convert jthrowable to jstring
+jstring javaStacktrace_tostring(JNIEnv*, jthrowable);
 
 // convert java exception to ImportError.
 // true (1) if an exception was processed.


### PR DESCRIPTION
This changeset makes JepExceptions include the entire Python traceback and Java Stacktrace, depending on where the original error was thrown.

This perhaps need to be more configurable as some applications may not want to include either trace while other applications will require full traces to properly diagnose and fix bugs.