### PR TITLE
Use sequence protocol to support FrameSummary objects

### DIFF
--- a/src/jep/util.c
+++ b/src/jep/util.c
@@ -446,12 +446,12 @@ int process_py_exception(JNIEnv *env, int printTrace) {
                     // java order is classname, methodname, filename, lineNumber
                     // python order is filename, line number, function name, line
                     charPyFile = PyString_AsString(
-                            PyTuple_GetItem(stackEntry, 0));
+                            PySequence_GetItem(stackEntry, 0));
                     pyLineNum = (int) PyInt_AsLong(
-                            PyTuple_GetItem(stackEntry, 1));
+                            PySequence_GetItem(stackEntry, 1));
                     charPyFunc = PyString_AsString(
-                            PyTuple_GetItem(stackEntry, 2));
-                    pyLine = PyTuple_GetItem(stackEntry, 3);
+                            PySequence_GetItem(stackEntry, 2));
+                    pyLine = PySequence_GetItem(stackEntry, 3);
 
                     /*
                      * if pyLine is None, this seems to imply it was an eval,


### PR DESCRIPTION
Jep will crash the JVM with Python 3.5 in case of an exception otherwise.

I've not checked older Python versions or run the tests. I don't think this change causes trouble because as far as I known tuples implement the sequence protocol, too.