### PR TITLE
Support setting python initialization variables

### DIFF
--- a/src/jep/Jep.java
+++ b/src/jep/Jep.java
@@ -57,6 +57,8 @@ public final class Jep implements Closeable {
 
     private static final String THREAD_WARN = "JEP THREAD WARNING: ";
 
+    private static TopInterpreter topInterpreter = null;
+
     private boolean closed = false;
 
     private long tstate = 0;
@@ -95,17 +97,18 @@ public final class Jep implements Closeable {
     };
 
     /**
-     * Loads the jep library (e.g. libjep.so or jep.dll) and initializes the
-     * main Python interpreter that all sub-interpreters will be created from.
+     * Initializes the main Python interpreter that all sub-interpreters will
+     * be created from.
      */
-    private static class TopInterpreter {
+    private static class TopInterpreter implements Closeable {
+        Object initLock;
         Throwable error;
 
         /**
-         * Loads the jep library, which will in turn initialize CPython, ie
-         * Py_Initialize(). We load on a separate thread to try and avoid GIL
-         * issues that come about from a sub-interpreter being on the same
-         * thread as the top/main interpreter.
+         * Initializes CPython, by calling a native function in the jep module,
+         * and ultimately Py_Initialize(). We load on a separate thread to try
+         * and avoid GIL issues that come about from a sub-interpreter being
+         * on the same thread as the top/main interpreter.
          * 
          * @throws Error
          */
@@ -115,7 +118,7 @@ public final class Jep implements Closeable {
                 @Override
                 public void run() {
                     try {
-                        System.loadLibrary("jep");
+                        initializePython();
                     } catch (Throwable t) {
                         error = t;
                     } finally {
@@ -129,7 +132,7 @@ public final class Jep implements Closeable {
                      * while another thread is in python, then the thread state
                      * can get messed up leading to stability/GIL issues.
                      */
-                    Object initLock = new Object();
+                    initLock = new Object();
                     synchronized (initLock) {
                         try {
                             initLock.wait();
@@ -151,25 +154,72 @@ public final class Jep implements Closeable {
                 }
             }
             if (error != null) {
-                if (error instanceof UnsatisfiedLinkError) {
-                    /*
-                     * This ensures the exception message
-                     * "no jep in java.library.path" while providing the full
-                     * stacktrace of what thread tried to initialize Jep.
-                     */
-                    UnsatisfiedLinkError up = new UnsatisfiedLinkError(
-                            error.getMessage());
-                    up.initCause(error);
-                    throw up;
-                }
                 throw new Error(error);
+            }
+        }
+
+        /**
+         * Stop the interpreter thread.
+         */
+        @Override
+        public synchronized void close() {
+            if (null != initLock) {
+                initLock.notify();
+                initLock = null;
             }
         }
     }
 
     static {
-        TopInterpreter python = new TopInterpreter();
-        python.initialize();
+        System.loadLibrary("jep");
+    }
+
+    /**
+     * Sets interpreter settings for the top Python interpreter. This method
+     * must be called before the first Jep instance is created in the process.
+     *
+     * @param config the python configuration to use.
+     */
+    public static void setInitParams(PyConfig config) throws JepException {
+        if (null != topInterpreter) {
+            throw new JepException(
+              "Jep.setInitParams called after initializing python interpreter.");
+        }
+        setInitParams(
+            config.noSiteFlag,
+            config.noUserSiteDirectory,
+            config.ignoreEnvironmentFlag);
+    }
+
+    private static native void setInitParams(
+        int noSiteFlag,
+        int noUserSiteDiretory,
+        int ignoreEnvironmentFlag);
+
+    private static native void initializePython();
+
+    /**
+     * Creates the TopInterpreter instance that will be used by Jep.
+     * This should be called from all Jep constructors to ensure the native
+     * module has been loaded and initialized before a valid Jep instance is
+     * produced.
+     *
+     * @throws Error
+     */
+    private synchronized static void createTopInterpreter() throws Error {
+        if (null == topInterpreter) {
+            try {
+                topInterpreter = new TopInterpreter();
+                topInterpreter.initialize();
+            } catch (Throwable t) {
+                topInterpreter.close();
+                throw t;
+            }
+        } else if (null != topInterpreter.error) {
+            throw new Error(
+                "The main python interpreter previously failed to initialize.",
+                topInterpreter.error);
+        }
     }
 
     // -------------------------------------------------- constructors
@@ -262,6 +312,7 @@ public final class Jep implements Closeable {
     }
 
     public Jep(JepConfig config) throws JepException {
+        createTopInterpreter();
         if (threadUsed.get()) {
             /*
              * TODO: Throw a JepException if this is detected. This is

--- a/src/jep/PyConfig.java
+++ b/src/jep/PyConfig.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016 JEP AUTHORS.
+ *
+ * This file is licensed under the the zlib/libpng License.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any
+ * damages arising from the use of this software.
+ * 
+ * Permission is granted to anyone to use this software for any
+ * purpose, including commercial applications, and to alter it and
+ * redistribute it freely, subject to the following restrictions:
+ * 
+ *     1. The origin of this software must not be misrepresented; you
+ *     must not claim that you wrote the original software. If you use
+ *     this software in a product, an acknowledgment in the product
+ *     documentation would be appreciated but is not required.
+ * 
+ *     2. Altered source versions must be plainly marked as such, and
+ *     must not be misrepresented as being the original software.
+ * 
+ *     3. This notice may not be removed or altered from any source
+ *     distribution.
+ */
+package jep;
+
+/**
+ * <p>
+ * A configuration object for setting Python pre-initialization parameters.
+ * </p>
+ *
+ * @author Jeff V Stein
+ */
+public class PyConfig {
+
+    protected int noSiteFlag = -1;
+    protected int noUserSiteDirectory = -1;
+    protected int ignoreEnvironmentFlag = -1;
+
+    /**
+     * Set the Py_NoSiteFlag variable on the python interpreter. This
+     * corresponds to the python "-S" flag and will prevent the "site" module
+     * from being automatically loaded.
+     * 
+     * @param noSiteFlag value to pass to Python for Py_NoSiteFlag
+     * @return a reference to this PyConfig
+     */
+    public PyConfig setNoSiteFlag(int noSiteFlag) {
+        this.noSiteFlag = noSiteFlag;
+        return this;
+    }
+
+    /**
+     * Set the Py_NoUserSiteDirectory variable on the python interpreter. This
+     * corresponds to the python "-s" flag and will prevent the user's local
+     * python site directory from being added to sys.path.
+     * 
+     * @param noUserSiteDirectory value to pass to Python for
+     *        Py_NoUserSiteDirectory
+     * @return a reference to this PyConfig
+     */
+    public PyConfig setNoUserSiteDirectory(int noUserSiteDirectory) {
+        this.noUserSiteDirectory = noUserSiteDirectory;
+        return this;
+    }
+
+    /**
+     * Set the Py_IgnoreEnvironmentFlag variable on the python interpreter.
+     * This corresponds to the python "-E" flag and will instruct python to
+     * ignore all PYTHON* environment variables (e.g. PYTHONPATH).
+     * 
+     * @param ignoreEnvironmentFlag value to pass to Python for
+     *        Py_IgnoreEnvironmentFlag
+     * @return a reference to this PyConfig
+     */
+    public PyConfig setIgnoreEnvironmentFlag(int ignoreEnvironmentFlag) {
+        this.ignoreEnvironmentFlag = ignoreEnvironmentFlag;
+        return this;
+    }
+}

--- a/src/jep/jep.c
+++ b/src/jep/jep.c
@@ -48,7 +48,6 @@ BOOL APIENTRY DllMain(HANDLE hModule,
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
 {
-    pyembed_startup();
     return JNI_VERSION_1_2;
 }
 
@@ -59,6 +58,32 @@ JNI_OnUnload(JavaVM *vm, void *reserved)
     pyembed_shutdown(vm);
 }
 
+
+/*
+ * Class:     jep_Jep
+ * Method:    setInitParams
+ * Signature: (III)V
+ */
+JNIEXPORT void JNICALL Java_jep_Jep_setInitParams
+(JNIEnv *env,
+ jclass class,
+ jint noSiteFlag,
+ jint noUserSiteDirectory,
+ jint ignoreEnvironmentFlag)
+{
+    pyembed_preinit(noSiteFlag, noUserSiteDirectory, ignoreEnvironmentFlag);
+}
+
+/*
+ * Class:     jep_Jep
+ * Method:    initializePython
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_jep_Jep_initializePython
+(JNIEnv *env, jclass class)
+{
+    pyembed_startup();
+}
 
 /*
  * Class:     jep_Jep

--- a/src/jep/pyembed.c
+++ b/src/jep/pyembed.c
@@ -196,6 +196,20 @@ static PyObject* initjep(void)
     return modjep;
 }
 
+void pyembed_preinit(jint noSiteFlag,
+                     jint noUserSiteDirectory,
+                     jint ignoreEnvironmentFlag)
+{
+    if (noSiteFlag >= 0) {
+        Py_NoSiteFlag = noSiteFlag;
+    }
+    if (noUserSiteDirectory >= 0) {
+        Py_NoUserSiteDirectory = noUserSiteDirectory;
+    }
+    if (ignoreEnvironmentFlag >= 0) {
+        Py_IgnoreEnvironmentFlag = ignoreEnvironmentFlag;
+    }
+}
 
 void pyembed_startup(void)
 {

--- a/src/jep/pyembed.h
+++ b/src/jep/pyembed.h
@@ -48,6 +48,7 @@ struct __JepThread {
 typedef struct __JepThread JepThread;
 
 
+void pyembed_preinit(jint, jint, jint);
 void pyembed_startup(void);
 void pyembed_shutdown(JavaVM*);
 


### PR DESCRIPTION
- Separated native library loading from initialization of python interpreter.
- Cleaned up UnsatisfiedLinkError stacktrace.
- Added Jep.setInitParams method to be callable before creating a Jep instance.